### PR TITLE
Bug fixes - Group filters

### DIFF
--- a/src/components/elements/controlledDisplayFiltersGroup/index.tsx
+++ b/src/components/elements/controlledDisplayFiltersGroup/index.tsx
@@ -3,6 +3,7 @@ import { Box, Divider } from '@mui/material';
 import { DisplayFilter } from '../displayFilter';
 import React from 'react';
 import { LabeledSwitch } from '../../forms';
+import _ from 'lodash';
 
 export interface DisplayFilterPartialProps {
   label: string;
@@ -11,16 +12,14 @@ export interface DisplayFilterPartialProps {
 
 export interface ControlledDisplayFiltersGroupProps {
   filters: DisplayFilterPartialProps[];
-  label?: string;
+  toggleAllLabel?: string;
   toggleShowAll: (show: boolean) => void;
-  onFilterChange: (name: string, show: boolean) => void;
 }
 
 export function ControlledDisplayFiltersGroup({
   filters,
-  onFilterChange,
   toggleShowAll,
-  label
+  toggleAllLabel
 }: ControlledDisplayFiltersGroupProps) {
   const [showAll, setShowAll] = useState<boolean>(false);
   const [displayedFilters, setDisplayedFilters] = useState<Set<string>>(() => new Set<string>());
@@ -38,38 +37,19 @@ export function ControlledDisplayFiltersGroup({
     toggleShowAll(!showAll);
   };
 
-  function setsAreEqual(setA:Set<string>, setB:Set<string>) {
-    if (setA.size !== setB.size) {
-      return false;
-    }
-    for (const item of setA) {
-      if (!setB.has(item)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   useEffect(() => {
     // When metadataToDisplay changes, check if it's equal to availableFiltersNames
-    if (setsAreEqual(displayedFilters, availableFiltersNames)) {
+    if (_.isEqual(displayedFilters, availableFiltersNames)) {
       setShowAll(true);
     } else {
       setShowAll(false);
     }
   }, [displayedFilters, availableFiltersNames]);
 
-  const updateFilter = (item: DisplayFilterPartialProps, show: boolean) => {
-    if(item.onChange){
-      item.onChange(show)
-    }
-    onFilterChange(item.label, show);
-  };
-
   return (
     <Box sx={{ backgroundColor: 'rgba(248, 250, 252, 1)' }}>
       <Box>
-        <LabeledSwitch label={label} onChange={toggleAll} checked={showAll}/>
+        <LabeledSwitch label={toggleAllLabel} onChange={toggleAll} checked={showAll}/>
       </Box>
       {filters.map((item) => {
         return (
@@ -85,9 +65,10 @@ export function ControlledDisplayFiltersGroup({
                   updatedFilters.add(item.label);
                 }
                 setDisplayedFilters(updatedFilters);
-
-                updateFilter(item, show)
-              }}
+                if(item.onChange)
+                  item.onChange(show)
+                }
+              }
             />
             <Divider sx={{ backgroundColor: '#F8FAFC' }} />
           </>

--- a/src/components/forms/labeledSwitch/index.tsx
+++ b/src/components/forms/labeledSwitch/index.tsx
@@ -52,12 +52,12 @@ const StyledSwitch = styled((props: SwitchProps) => (
   }
 }));
 
-export function LabeledSwitch({ onChange, label }: { onChange: () => void; label?: string }) {
+export function LabeledSwitch({ onChange, label , checked}: { onChange: () => void; label?: string, checked: boolean }) {
   return (
     <FormGroup>
       <FormControlLabel
         onChange={onChange}
-        control={<StyledSwitch sx={{ m: 1 }} />}
+        control={<StyledSwitch sx={{ m: 1 }} checked={checked}/>}
         label={label}
         labelPlacement={'start'}
         sx={{

--- a/src/stories/elements/controlledDisplayFiltersGroup/ControlledDisplayFiltersGroup.stories.tsx
+++ b/src/stories/elements/controlledDisplayFiltersGroup/ControlledDisplayFiltersGroup.stories.tsx
@@ -35,5 +35,5 @@ ControlledDisplayFilterBasic.args = {
   ],
   onFilterChange: (value) => console.log('show all', value),
   toggleShowAll: (value) => console.log('toggle show all', value),
-  label: 'Show all'
+  toggleAllLabel: 'Show all'
 };


### PR DESCRIPTION
- Make the filter's `onChange` prop not mandatory.
- In case an onChange function is passed, invoke it (it has not been invoked by now).
- Fix showAll toggle value, when manually toggling all filters on/off.