### PR TITLE
Fix theme and UI bug in the metadata list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dagshub/ui",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dagshub/ui",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/dagshub/design-system.git"
   },
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "A component library for consuming dagshub user interfaces.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/dagshub/data-engine/metadataKeyValue/MetadataKeyValueList.tsx
+++ b/src/components/dagshub/data-engine/metadataKeyValue/MetadataKeyValueList.tsx
@@ -193,7 +193,8 @@ export function MetadataKeyValueList({
         display: 'flex',
         flexDirection: 'column',
         height: '100%',
-        maxHeight: maxHeight ?? '100%'
+        maxHeight: maxHeight ?? '100%',
+        overflowX: 'hidden',
       }}
     >
       <Box
@@ -203,7 +204,8 @@ export function MetadataKeyValueList({
           flexDirection: 'column',
           height: '100%',
           maxHeight: '100%',
-          overflowY: 'auto'
+          overflowY: 'auto',
+          overflowX: 'hidden',
         }}
       >
         {temporaryMetadataList.map((metadataField, index) => (

--- a/src/components/dagshub/data-engine/metadataKeyValue/MetadataKeyValuePair.tsx
+++ b/src/components/dagshub/data-engine/metadataKeyValue/MetadataKeyValuePair.tsx
@@ -74,7 +74,7 @@ export function MetadataKeyValuePair({
         backgroundColor: '#F8FAFC',
         borderBottom: '1px solid #E2E8F0',
         alignItems: 'center',
-        flexWrap: isNewlyCreated ? 'wrap' : 'nowrap'
+        flexWrap: isNewlyCreated ? 'wrap' : 'nowrap', overflowX: 'hidden',
       }}
     >
       <Box
@@ -107,7 +107,7 @@ export function MetadataKeyValuePair({
           flexGrow: 1,
           maxWidth: '100%',
           gap: '8px',
-          flexShrink: 0,
+          flexShrink: 1,
           minWidth: '65%'
         }}
       >

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,6 +7,7 @@ declare module '@mui/material/Typography' {
         medium: true;
         mediumBold: true;
         large: true;
+        overflow: true;
     }
 }
 
@@ -19,16 +20,15 @@ const lightTheme = createTheme({
     },
     components: {
         MuiTypography:{
-            styleOverrides: {
-                root: {
-                    fontFamily: 'Inter',
-                    color: 'rgba(23, 45, 50, 1)',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                },
-            },
             variants: [
+                {
+                    props: { variant: 'overflow' },
+                    style: {
+                        textOverflow: 'ellipsis',
+                        overflow: 'hidden',
+                        whiteSpace: 'nowrap',
+                    },
+                },
                 {
                     props: { variant: 'small' },
                     style: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,6 +20,11 @@ const lightTheme = createTheme({
     },
     components: {
         MuiTypography:{
+            styleOverrides: {
+                root: {
+                    fontFamily: 'Inter',
+                },
+            },
             variants: [
                 {
                     props: { variant: 'overflow' },


### PR DESCRIPTION
- Fix theme to not ovveride the root typography, but have the overflow css as a separate variant.
- fix ui bug in small screens,  in the metadata key-value list.

Before:
<img width="283" alt="image" src="https://github.com/DagsHub/design-system/assets/107917894/1fd2a640-1164-478e-ba14-ef3ba3750c12">

After:
<img width="289" alt="image" src="https://github.com/DagsHub/design-system/assets/107917894/88e0dff3-a890-4426-a2e0-f5b5a91e428f">
